### PR TITLE
Document update behavior

### DIFF
--- a/src/Dict/LLRB.elm
+++ b/src/Dict/LLRB.elm
@@ -433,6 +433,9 @@ moveRedRight dict =
 
 
 {-| Update the value of a dictionary for a specific key with a given function.
+The given function gets the current value as a parameter and its return value
+determines if the value is updated or removed. New key-value pairs can be
+inserted too.
 -}
 update : comparable -> (Maybe v -> Maybe v) -> Dict comparable v -> Dict comparable v
 update key alter dict =


### PR DESCRIPTION
I found I couldn't really tell whether `update` inserts a non-existing key or not from the documentation, so I decided to clarify it a little.